### PR TITLE
Update to latest packages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,11 +15,11 @@
     "url": "https://github.com/nwolverson/purescript-csv.git"
   },
   "dependencies": {
-    "purescript-console": "^1.0.0",
-    "purescript-parsing": "^1.0.0",
-    "purescript-arrays": "^1.1.0",
-    "purescript-quickcheck": "^1.0.0",
-    "purescript-test-unit": "^9.1.0",
-    "purescript-maps": "^1.2.0"
+    "purescript-console": "^2.0.0",
+    "purescript-parsing": "^3.2.0",
+    "purescript-arrays": "^3.2.0",
+    "purescript-quickcheck": "^3.1.1",
+    "purescript-test-unit": "^10.1.0",
+    "purescript-maps": "^2.1.1"
   }
 }

--- a/src/Text/Parsing/CSV.purs
+++ b/src/Text/Parsing/CSV.purs
@@ -62,7 +62,7 @@ makeFileHeaded file = do
     Nil -> Nil
     Cons header rows -> mkRow header <$> rows
   where
-    mkRow header row' = M.fromList $ zip header row'
+    mkRow header row' = M.fromFoldable $ zip header row'
 
 makeParsers :: Char -> String -> String -> Parsers String
 makeParsers quote seperator eol = do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -47,7 +47,7 @@ testFileResult = fromFoldable $ fromFoldable <$> testData
 testFileEmptyEndLineResult :: List (List String)
 testFileEmptyEndLineResult = fromFoldable $ fromFoldable <$> testData <> [[""]]
 
-main :: forall a. Eff (testOutput :: TESTOUTPUT, console :: CONSOLE | a) Unit
+main :: ∀ e. Eff ( console ∷ CONSOLE , err ∷ EXCEPTION , process ∷ PROCESS , random ∷ RANDOM | e ) Unit
 main = runTest do
   test "chars" do
     assert "parses chars" $ parses defaultParsers.chars "abc" "abc"


### PR DESCRIPTION
Hey! I wanted to try out using `purescript-csv` in a project I'm
working on, but ran into bower package resolution errors when `bower
install`ing.

I upgraded the packages to their latest versions, and made a few changes
to the source to get the code to compile. It looks like the project
builds cleanly under both `pulp build` and `pulp test` with these
changes.

I'm using this change by point bower directly at my fork on GitHub, but
it would be great if you could review these updates and publish a new
version to bower!

Let me know if anything looks off, but I think it looks pretty standard.