### PR TITLE
Version 0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .psc-ide-port
 bower_components
 output
+.spago

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,105 @@
+{-
+Welcome to your new Dhall package-set!
+
+Below are instructions for how to edit this file for most use
+cases, so that you don't need to know Dhall to use it.
+
+## Use Cases
+
+Most will want to do one or both of these options:
+1. Override/Patch a package's dependency
+2. Add a package not already in the default package set
+
+This file will continue to work whether you use one or both options.
+Instructions for each option are explained below.
+
+### Overriding/Patching a package
+
+Purpose:
+- Change a package's dependency to a newer/older release than the
+    default package set's release
+- Use your own modified version of some dependency that may
+    include new API, changed API, removed API by
+    using your custom git repo of the library rather than
+    the package set's repo
+
+Syntax:
+where `entityName` is one of the following:
+- dependencies
+- repo
+- version
+-------------------------------
+let upstream = --
+in  upstream
+  with packageName.entityName = "new value"
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with halogen.version = "master"
+  with halogen.repo = "https://example.com/path/to/git/repo.git"
+
+  with halogen-vdom.version = "v4.0.0"
+  with halogen-vdom.dependencies = [ "extra-dependency" ] # halogen-vdom.dependencies
+-------------------------------
+
+### Additions
+
+Purpose:
+- Add packages that aren't already included in the default package set
+
+Syntax:
+where `<version>` is:
+- a tag (i.e. "v4.0.0")
+- a branch (i.e. "master")
+- commit hash (i.e. "701f3e44aafb1a6459281714858fadf2c4c2a977")
+-------------------------------
+let upstream = --
+in  upstream
+  with new-package-name =
+    { dependencies =
+       [ "dependency1"
+       , "dependency2"
+       ]
+    , repo =
+       "https://example.com/path/to/git/repo.git"
+    , version =
+        "<version>"
+    }
+-------------------------------
+
+Example:
+-------------------------------
+let upstream = --
+in  upstream
+  with benchotron =
+      { dependencies =
+          [ "arrays"
+          , "exists"
+          , "profunctor"
+          , "strings"
+          , "quickcheck"
+          , "lcg"
+          , "transformers"
+          , "foldable-traversable"
+          , "exceptions"
+          , "node-fs"
+          , "node-buffer"
+          , "node-readline"
+          , "datetime"
+          , "now"
+          ]
+      , repo =
+          "https://github.com/hdgarrood/purescript-benchotron.git"
+      , version =
+          "v7.0.0"
+      }
+-------------------------------
+-}
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20221127/packages.dhall
+        sha256:9619da55468363705b888350fdd38735a5e90dab101f8d9193057552c5efccad
+
+in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,31 @@
+{-
+Welcome to a Spago project!
+You can edit this file as you like.
+
+Need help? See the following resources:
+- Spago documentation: https://github.com/purescript/spago
+- Dhall language tour: https://docs.dhall-lang.org/tutorials/Language-Tour.html
+
+When creating a new Spago project, you can use
+`spago init --no-comments` or `spago init -C`
+to generate this file without the comments in this block.
+-}
+{ name = "csv"
+, dependencies =
+  [ "arrays"
+  , "control"
+  , "effect"
+  , "either"
+  , "foldable-traversable"
+  , "lists"
+  , "maybe"
+  , "ordered-collections"
+  , "parsing"
+  , "prelude"
+  , "strings"
+  , "test-unit"
+  ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+, repository = "https://github.com/nwolverson/purescript-csv"
+}

--- a/src/Parsing/CSV.purs
+++ b/src/Parsing/CSV.purs
@@ -1,4 +1,4 @@
-module Text.Parsing.CSV where
+module Parsing.CSV where
 
 import Prelude hiding (between)
 import Data.Map as M
@@ -7,9 +7,9 @@ import Data.Array (some)
 import Data.Foldable (all)
 import Data.List (List(..), zip)
 import Data.String.CodeUnits (fromCharArray, toCharArray, singleton)
-import Text.Parsing.Parser (Parser)
-import Text.Parsing.Parser.Combinators (sepEndBy, sepBy1, between)
-import Text.Parsing.Parser.String (eof, satisfy, string)
+import Parsing (Parser)
+import Parsing.Combinators (sepEndBy, sepBy, between)
+import Parsing.String (eof, satisfy, string)
 
 type P a = Parser String a
 
@@ -46,7 +46,7 @@ makeField :: (P String -> P String) -> P String -> P String -> P String
 makeField qoutes qoutedChars purechars = qoutes qoutedChars <|> purechars <|> string ""
 
 makeRow :: String -> P String -> P (List String)
-makeRow s f = f `sepBy1` string s
+makeRow s f = f `sepBy` string s
 
 makeFile :: String -> P (List String) -> P (List (List String))
 makeFile s r = r `sepEndBy` string s <* eof

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,8 +10,8 @@ import Effect (Effect)
 import Test.Unit (test)
 import Test.Unit.Assert (assert)
 import Test.Unit.Main (runTest)
-import Text.Parsing.CSV (P, Parsers, defaultParsers, makeParsers)
-import Text.Parsing.Parser (runParser)
+import Parsing.CSV (P, Parsers, defaultParsers, makeParsers)
+import Parsing (runParser)
 
 excelParsers :: Parsers String
 excelParsers = makeParsers '\'' ";" "\r\n"


### PR DESCRIPTION
I've ported purescript-csv to version 0.15.  Text.Parsing.* has been renamed to Parsing.*, so I updated the import statements.  I also  changed the module name to Parsing.CSV to match the new name scheme.  Also sepBy1 was removed.  I used sepBy instead, and the tests passed so I assume that worked.

I have also added spago.dhall and packages.dhall.  I did not update the dependencies in bower.json.